### PR TITLE
fix unable to extract some 7z archives

### DIFF
--- a/shared/SevenZip/ArchiveFileModel.cs
+++ b/shared/SevenZip/ArchiveFileModel.cs
@@ -300,7 +300,7 @@ namespace ManagedLzma.SevenZip.FileModel
                             var attr = mAttributes[currentFileIndex];
 
                             if (attr.HasValue && (attr.Value & ArchivedAttributesExtensions.DirectoryAttribute) != 0)
-                                throw new InvalidDataException();
+                                continue;
 
                             file.Attributes = attr;
                         }


### PR DESCRIPTION
my suspicion is its archives that have a file name that matches also a folder name.