### PR TITLE
Bugfixes for large 7z files (dealing with multiple sections and int overflow)

### DIFF
--- a/shared/Compression/Lzma/Decoder.cs
+++ b/shared/Compression/Lzma/Decoder.cs
@@ -177,7 +177,7 @@ namespace ManagedLzma.LZMA
 
             long outputLimit = mDecoder.mDicBufSize;
             if (limit.HasValue)
-                outputLimit = Math.Min(outputLimit, mDecoderPosition + limit.Value);
+                outputLimit = Math.Min(outputLimit, (long)mDecoderPosition + limit.Value);
 
             long inputField = length;
             var res = mDecoder.LzmaDec_DecodeToDic(outputLimit, P.From(buffer, offset), ref inputField, mode, out mStatus);

--- a/shared/Compression/Lzma2/Decoder.cs
+++ b/shared/Compression/Lzma2/Decoder.cs
@@ -175,7 +175,7 @@ namespace ManagedLzma.LZMA2
 
             long outputLimit = mDecoder.mDecoder.mDicBufSize;
             if (limit.HasValue)
-                outputLimit = Math.Min(outputLimit, mDecoderPosition + limit.Value);
+                outputLimit = Math.Min(outputLimit, (long)mDecoderPosition + limit.Value);
 
             long inputField = length;
             var res = mDecoder.Lzma2Dec_DecodeToDic(outputLimit, LZMA.P.From(buffer, offset), ref inputField, mode, out mStatus);

--- a/shared/SevenZip/ArchiveFileModel.cs
+++ b/shared/SevenZip/ArchiveFileModel.cs
@@ -300,7 +300,7 @@ namespace ManagedLzma.SevenZip.FileModel
                             var attr = mAttributes[currentFileIndex];
 
                             if (attr.HasValue && (attr.Value & ArchivedAttributesExtensions.DirectoryAttribute) != 0)
-                                throw new InvalidDataException();
+                                continue;
 
                             file.Attributes = attr;
                         }

--- a/shared/SevenZip/ArchiveMetadataReader.cs
+++ b/shared/SevenZip/ArchiveMetadataReader.cs
@@ -906,7 +906,7 @@ namespace ManagedLzma.SevenZip.Reader
                                 throw new InvalidDataException();
 
                             connected = true;
-                            decoder.InputInfo[i] = new DecoderInputMetadata(null, 0);
+                            decoder.InputInfo[i] = new DecoderInputMetadata(null, rawInputStreamIndex);
                         }
                     }
                 }


### PR DESCRIPTION
There a 3 bugfixes here:
- The 2 places I found that have integer value overflow (!) leading to incorrect processing of large archives.
- Not setting stream id leading to incorrect processing of archives with several sections
- There are files created by 7zip with directory entries, that could simply be ignored instead of throwing an exception